### PR TITLE
Fix legend hiding for path collections

### DIFF
--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -600,14 +600,14 @@ class InteractiveLegendPlugin(PluginBase):
                     d3.select(d.mpld3_elements[i].path.nodes()[0])
                         .style("stroke-opacity", is_over ? current_alpha_over :
                                                 (d.visible ? current_alpha : current_alpha_unsel))
-                        .style("stroke-width", is_over ? 
+                        .style("stroke-width", is_over ?
                                 alpha_over * d.mpld3_elements[i].props.edgewidth : d.mpld3_elements[i].props.edgewidth);
                 } else if((type=="mpld3_PathCollection")||
                          (type=="mpld3_Markers")){
                     var current_alpha = d.mpld3_elements[i].props.alphas[0];
                     var current_alpha_unsel = current_alpha * alpha_unsel;
                     var current_alpha_over = current_alpha * alpha_over;
-                    d3.selectAll(d.mpld3_elements[i].pathsobj[0])
+                    d.mpld3_elements[i].pathsobj
                         .style("stroke-opacity", is_over ? current_alpha_over :
                                                 (d.visible ? current_alpha : current_alpha_unsel))
                         .style("fill-opacity", is_over ? current_alpha_over :


### PR DESCRIPTION
Previously, toggling visibility from the legend using the plugin did not work for path collections. It now does.